### PR TITLE
Studyページの追加

### DIFF
--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -21,13 +21,10 @@ var routes = [
     path: '/form/',
     component: FormPage,
   },
-
   {
     path: '/study/',
     component: StudyPage,
   },
-
-
   {
     path: '/dynamic-route/blog/:blogId/post/:postId/',
     component: DynamicRoutePage,

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -2,6 +2,7 @@
 import HomePage from '../pages/home.f7';
 import AboutPage from '../pages/about.f7';
 import FormPage from '../pages/form.f7';
+import StudyPage from '../pages/study.f7';
 
 import DynamicRoutePage from '../pages/dynamic-route.f7';
 import RequestAndLoad from '../pages/request-and-load.f7';
@@ -20,6 +21,12 @@ var routes = [
     path: '/form/',
     component: FormPage,
   },
+
+  {
+    path: '/study/',
+    component: StudyPage,
+  },
+
 
   {
     path: '/dynamic-route/blog/:blogId/post/:postId/',

--- a/src/pages/home.f7
+++ b/src/pages/home.f7
@@ -56,6 +56,15 @@
               </div>
             </a>
           </li>
+
+          <li>
+            <a href="/study/" class="item-content item-link">
+              <div class="item-inner">
+                <div class="item-title">Study</div>
+              </div>
+            </a>
+          </li>
+
         </ul>
       </div>
 

--- a/src/pages/study.f7
+++ b/src/pages/study.f7
@@ -1,0 +1,21 @@
+<template>
+<div class="page" data-name="about">
+    <div class="navbar">
+    <div class="navbar-bg"></div>
+    <div class="navbar-inner sliding">
+        <div class="left">
+        <a href="#" class="link back">
+            戻る
+        </a>
+        </div>
+        <div class="title">JS学習用ページ</div>
+    </div>
+    </div>
+    
+</div>
+</template>
+<script>
+export default () => {
+    return $render;
+};
+</script>

--- a/src/pages/study.f7
+++ b/src/pages/study.f7
@@ -1,21 +1,15 @@
 <template>
-<div class="page" data-name="about">
+<div class="page" data-name="study">
     <div class="navbar">
-    <div class="navbar-bg"></div>
-    <div class="navbar-inner sliding">
-        <div class="left">
-        <a href="#" class="link back">
-            戻る
-        </a>
+        <div class="navbar-bg"></div>
+        <div class="navbar-inner sliding">
+            <div class="left">
+                <a href="#" class="link back">
+                    戻る
+                </a>
+            </div>
+            <div class="title">JS学習用ページ</div>
         </div>
-        <div class="title">JS学習用ページ</div>
     </div>
-    </div>
-    
 </div>
 </template>
-<script>
-export default () => {
-    return $render;
-};
-</script>


### PR DESCRIPTION
# Studyページの追加
homeページの項目欄に新しくStudyページが表示されるリンクを追加しました。

## 変更点
- src/js/routes.js 
  - homeページに新しく追加したStudyのリンクからStudyPageへ画面遷移できるようにルーティングを追加しました。

- src/pages/home.f7
  - homeページに、新規作成したstudy.f7へ画面遷移するためのリンクを追加しました。

- src/pages/study.f7
  - 学習用のページを新規作成しました。

## その他


### 参考資料
- 以下のサイトを参考して実装致しました。
  - [Framework7](https://framework7.jp/docs/navbar.html)

### セルフチェック項目
- [x] `console`にエラーがないことを確認しました。
- [x] ローカルが起動することを確認しました。
- [x] 命名規則は統一して実装しています。
- [x] 複雑な処理にはコメントを残しました。
- [x] RVに必要な情報はPRに全て記載致しました。