### PR TITLE
複数のイメージファイルの表示

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -51,8 +51,18 @@ var app = new Framework7({
       }
       store.state.image = {
         "image_data": {
-          "image_url": "..\/..\/img\/studyIcon\/0a16fa82381c4bb981d07841408329f1_t.jpeg",
-          "link_path": "/home/"
+          "image1": {
+            "image_url": "..\/..\/img\/studyIcon\/0a16fa82381c4bb981d07841408329f1_t.jpeg",
+            "link_path": "/"
+          },
+          "image2": {
+            "image_url": "..\/img\/studyIcon\/51bb32664f5d1c379c45d348939eee4b_t.jpeg",
+            "link_path": "/form/"
+          },
+          "image3": {
+            "image_url": "..\/img\/studyIcon\/cc46614da92cf990a3609ffa2d1f3e0e_t.jpeg",
+            "link_path": "/about/"
+          }
         }
       };
     },

--- a/src/pages/study.f7
+++ b/src/pages/study.f7
@@ -18,14 +18,16 @@
         </p>
       </div>
       <div>
-        ${imageUrl[0] && $h`        
-        ${imageUrl.map((item) => $h`
-        <div class="study-photo">
-          <a href="${item.link_path}">
-            <img src="${item.image_url}"/>
-          </a>
+        ${imageUrl[0] && $h`
+        <div>
+          ${imageUrl.map((item) => $h`
+          <div class="study-photo">
+            <a href="${item.link_path}">
+              <img src="${item.image_url}"/>
+            </a>
+          </div>
+          `)}
         </div>
-        `)}
         `}
       </div>
     </div>
@@ -38,17 +40,17 @@
     let studyItem = []
     let imageUrl = []
 
-    //アラートの作成
+    // アラートの作成
     const popup = () => {
       alert("test");
     };
 
-    //イメージファイルの描画処理
+    // イメージファイルの描画処理
     getStudyItem()
     function getStudyItem() {
       studyItem.push($store.state.image.image_data)
       console.log("study",studyItem)
-      for(var i = 0; i < studyItem.length; i++){
+      for(let i = 0; i < studyItem.length; i++){
         imageUrl.push(studyItem[i].image1)
         imageUrl.push(studyItem[i].image2)
         imageUrl.push(studyItem[i].image3)

--- a/src/pages/study.f7
+++ b/src/pages/study.f7
@@ -17,8 +17,16 @@
           アラートを出力します
         </p>
       </div>
-      <div class="study-photo">
-        <img src="${imageUrl}"/>
+      <div>
+        ${imageUrl[0] && $h`        
+        ${imageUrl.map((item) => $h`
+        <div class="study-photo">
+          <a href="${item.link_path}">
+            <img src="${item.image_url}"/>
+          </a>
+        </div>
+        `)}
+        `}
       </div>
     </div>
   </div>
@@ -30,16 +38,20 @@
     let studyItem = []
     let imageUrl = []
 
+    //アラートの作成
     const popup = () => {
       alert("test");
     };
 
+    //イメージファイルの描画処理
     getStudyItem()
     function getStudyItem() {
       studyItem.push($store.state.image.image_data)
       console.log("study",studyItem)
       for(var i = 0; i < studyItem.length; i++){
-        imageUrl.push(studyItem[i].image_url)
+        imageUrl.push(studyItem[i].image1)
+        imageUrl.push(studyItem[i].image2)
+        imageUrl.push(studyItem[i].image3)
         console.log("imageUrl",imageUrl)
       }
       $update();


### PR DESCRIPTION
# 複数のイメージファイルの表示
複数のイメージファイルを表示させ、それぞれクリックをすると指定のリンクに飛ぶように処理を追加しました。

## 変更点
- src/js/app.js
  - 追加したイメージファイルのパスを追記しました。

- src/pages/study.f7
  - 複数のイメージファイルを表示しました。
  - 表示された画像をクリックすると、それぞれ指定のリンクに飛ぶように処理を追加しました。
  - 処理のコメントを追記しました。

## その他
### 実装詳細

### 参考資料
- 以下のサイトを参考して実装致しました。
  - [Cordova公式ドキュメント](https://framework7.jp/docs/introduction.html)

### セルフチェック項目
- [x] `console`にエラーがないことを確認しました。
- [x] ローカルが起動することを確認しました。
- [x] 命名規則は統一して実装しています。
- [x] 複雑な処理にはコメントを残しました。
- [x] RVに必要な情報はPRに全て記載致しました。
- [x] マージ先マージ元のブランチが正しいことを確認致しました。