### PR TITLE
紙吹雪処理の追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -519,6 +519,30 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
@@ -2304,12 +2328,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
-    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -3274,15 +3292,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -3667,14 +3676,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -3689,18 +3698,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -3721,15 +3718,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/trim-newlines": {
@@ -3788,15 +3776,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.8.tgz",
-      "integrity": "sha512-zsBGwn5UT3YS0NLSJ7hnR54+vUKfgzMUh/Z9CxF1YKEBVIe213+63jrFLmZphgGI5zXwQCSmqIdbPuE8NJywPw==",
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
+      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3845,23 +3833,6 @@
       },
       "peerDependencies": {
         "vite": ">=2.0.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/which": {
@@ -4241,6 +4212,29 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
       "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
       "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
+      }
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.13",
@@ -5412,12 +5406,6 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
-    },
     "lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -6078,12 +6066,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6338,14 +6320,14 @@
       }
     },
     "terser": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
@@ -6354,15 +6336,6 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.8.0-beta.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^7.0.0"
-          }
         }
       }
     },
@@ -6379,15 +6352,6 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
-      }
-    },
-    "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
       }
     },
     "trim-newlines": {
@@ -6431,16 +6395,16 @@
       }
     },
     "vite": {
-      "version": "2.9.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.8.tgz",
-      "integrity": "sha512-zsBGwn5UT3YS0NLSJ7hnR54+vUKfgzMUh/Z9CxF1YKEBVIe213+63jrFLmZphgGI5zXwQCSmqIdbPuE8NJywPw==",
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
+      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",
         "fsevents": "~2.3.2",
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       }
     },
     "vite-plugin-html": {
@@ -6461,23 +6425,6 @@
         "html-minifier-terser": "^6.1.0",
         "node-html-parser": "^5.3.3",
         "pathe": "^0.2.0"
-      }
-    },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "which": {

--- a/src/app.f7
+++ b/src/app.f7
@@ -137,7 +137,7 @@
   </div>
 </template>
 <script>
-  export default (props, { $f7, $update }) => {
+  export default (props, { $f7, $update, $store }) => {
     // Login screen demo data
     let username = '';
     let password = '';
@@ -158,8 +158,9 @@
     const closePanel = () => {
       const pagePanel = $f7.panel.get(".pagePanel")
       pagePanel.close();
+      // storeから紙吹雪を削除するコードを取得
+      $store.state.confettiStop();
     }
-
     return $render;
   }
 </script>

--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,8 @@
     * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
       * Enable inline JS: add 'unsafe-inline' to default-src
   -->
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: content:">
+  <meta http-equiv="Content-Security-Policy" 
+  content="worker-src blob: ;default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: content:">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover">
 
   <meta name="theme-color" content="#fff">
@@ -45,5 +46,6 @@
   </script>
   <% } %>
   <script type="module" src="./js/app.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>
 </body>
 </html>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -49,6 +49,52 @@ var app = new Framework7({
         // Init cordova APIs (see cordova-app.js)
         cordovaApp.init(f7);
       }
+
+      // 紙吹雪保存処理
+      var confetti_timer;
+      store.state.confettiStore = confettiStore
+      function confettiStore() {
+        confettiAnime()
+        confetti_timer = setInterval(function(){
+          requestAnimationFrame(confettiAnime)
+        }, 800)
+      }
+
+      // 紙吹雪表示処理
+      const confettiAnime = () => {
+        // 紙吹雪を表示する場所を指定
+        var element = $('canvas');
+        element.attr('class','canvasStyle');
+
+        // 紙吹雪の設定
+        confetti({
+          shapes:['square'],
+          scalar:1.5,
+          gravity:0.5,
+          spread: 130,
+          origin: {
+            x: Math.random(),
+            y: 0
+          },
+          particleCount: 7,
+          ticks: 1000,
+          zIndex: 10501,
+          colors: [
+            '#00A8F4',
+            '#F6D037',
+            '#FA96AA',
+            '#47CA2E',
+          ]
+        })
+      }
+
+      // 紙吹雪停止処理
+      store.state.confettiStop = intervalClear
+      function intervalClear() {
+        clearInterval(confetti_timer)
+        confetti.reset();
+      }
+
       store.state.image = {
         "image_data": {
           "image1": {

--- a/src/pages/study.f7
+++ b/src/pages/study.f7
@@ -36,7 +36,7 @@
             ${imageUrl.map((item) => $h`
             <div class="swiper-slide">            
               <div class="study-photo">
-                <a href="${item.link_path}">
+                <a href="${item.link_path}" @click="${confettiStop}">
                   <img src="${item.image_url}"/>
                 </a>
               </div>           
@@ -135,7 +135,7 @@
       $update();
     };
 
-    
+
     // フォーム内容を取得
     getForm()
     function getForm() {

--- a/src/pages/study.f7
+++ b/src/pages/study.f7
@@ -162,10 +162,10 @@
 
 
     // 紙吹雪処理
-    setTimeout(function(){
-      // storeから紙吹雪を表示するコードを取得
+    confettiStart()
+    function confettiStart(){
       $store.state.confettiStore()
-    },1000)
+    }
 
     const confettiStop = () => {
       // storeから紙吹雪を削除するコードを取得

--- a/src/pages/study.f7
+++ b/src/pages/study.f7
@@ -4,7 +4,7 @@
       <div class="navbar-bg"></div>
       <div class="navbar-inner sliding">
         <div class="left">
-          <a href="#" class="link back">
+          <a href="#" class="link back" @click="${confettiStop}">
             戻る
           </a>
         </div>
@@ -109,9 +109,8 @@
     </div>
   </div>
 </template>
-
 <script>
-  export default (props, { $store, $update }) => {
+  export default (props, { $store, $update, $}) => {
 
     let studyItem = []
     let imageUrl = []
@@ -122,6 +121,7 @@
     const popup = () => {
       alert("test");
     };
+
 
     // イメージファイルの描画処理
     getStudyItem()
@@ -135,6 +135,7 @@
       $update();
     };
 
+    
     // フォーム内容を取得
     getForm()
     function getForm() {
@@ -158,6 +159,18 @@
       };
       $update();
     };
+
+
+    // 紙吹雪処理
+    setTimeout(function(){
+      // storeから紙吹雪を表示するコードを取得
+      $store.state.confettiStore()
+    },1000)
+
+    const confettiStop = () => {
+      // storeから紙吹雪を削除するコードを取得
+      $store.state.confettiStop();
+    }
     return $render;
   }
 </script>

--- a/src/pages/study.f7
+++ b/src/pages/study.f7
@@ -110,7 +110,7 @@
   </div>
 </template>
 <script>
-  export default (props, { $store, $update, $}) => {
+  export default (props, { $store, $update}) => {
 
     let studyItem = []
     let imageUrl = []


### PR DESCRIPTION
# 紙吹雪処理の追加
studyページに移動すると紙吹雪が表示される処理を追加しました。

## 変更点
- src/app.f7
  - 紙吹雪を止めるコードをstoreから取得する処理を追加しました。
  - パネルから他のページへ移動したときに紙吹雪が止まるようにしました。

- src/index.html
  - CDNでjsファイルを読み込む処理を追加しました。

- src/js/app.js
  - storeに紙吹雪を表示させる処理を保存しました。
  - storeに紙吹雪を停止させる処理を追加しました

- src/pages/study.f7
  - 紙吹雪を表示するコードをstoreから取得する処理を追加しました
  - 紙吹雪を止めるコードをstoreから取得する処理を追加しました
  - studyページの戻るをクリックすると紙吹雪が止まるよう処理を追加しました
  - 画像をクリックしてページを移動すると、紙吹雪が止まる処理を追加しました

## その他

### 参考資料
- 以下のサイトを参考して実装致しました。
  - [npm canvas-confetti](https://www.npmjs.com/package/canvas-confetti)
  - [iwb.jp](https://iwb.jp/javascript-canvas-confetti-animation/)
  - [Qiita](https://qiita.com/goofmint/items/0b60dcc5eccad6c794a2)

### セルフチェック項目
- [x] `console`にエラーがないことを確認しました。
- [x] ローカルが起動することを確認しました。
- [x] 命名規則は統一して実装しています。
- [x] 複雑な処理にはコメントを残しました。
- [x] RVに必要な情報はPRに全て記載致しました。
- [x] マージ先マージ元のブランチが正しいことを確認致しました。