### PR TITLE
styleStudyページの作成

### DIFF
--- a/src/app.f7
+++ b/src/app.f7
@@ -59,6 +59,13 @@
                     </div>
                   </a>
                 </li>
+                <li>
+                  <a href="/styleStudy/" class="item-content item-link" @click="${closePanel}">
+                    <div class="item-inner">
+                      <div class="item-title">StyleStudy</div>
+                    </div>
+                  </a>
+                </li>      
               </ul>
             </div>
           </div>

--- a/src/css/styleStudy.scss
+++ b/src/css/styleStudy.scss
@@ -1,5 +1,5 @@
-.boxs1{
-    padding-top: 40px;
+.upperBox{
+    margin: 30px;
     display: flex;
     justify-content: space-around;
     .redBox {
@@ -15,8 +15,8 @@
         background: green;
     }
 }
-.boxs2{
-    padding-top: 40px;
+.underBox{
+    margin: 30px;
     display: flex;
     justify-content: space-around;
     .pinkBox {

--- a/src/css/styleStudy.scss
+++ b/src/css/styleStudy.scss
@@ -2,29 +2,29 @@
     padding-top: 40px;
     display: flex;
     justify-content: space-around;
-    .bc1 {
-         padding: 30px 30px 30px 30px;
-        background   : red;
+    .redBox {
+        padding: 30px;
+        background: red;
     }
-    .bc2 {
-         padding:  30px 30px 30px 30px;
-        background   : blue;
+    .blueBox {
+        padding:  30px;
+        background: blue;
     }
-    .bc3 {
-         padding:  30px 30px 30px 30px;
-        background   : green;
+    .greenBox {
+        padding:  30px;
+        background: green;
     }
 }
 .boxs2{
-    padding-top: 40px ;
+    padding-top: 40px;
     display: flex;
     justify-content: space-around;
-    .bc4 {
-         padding:  30px 30px 30px 30px;
-        background   : #ff7f7f;
+    .pinkBox {
+        padding:  30px;
+        background: pink;
     }
-    .bc5 {
-         padding:  30px 30px 30px 30px; 
-        background   : #ff66ff;
+    .violetBox {
+        padding:  30px; 
+        background: violet;
     }
 }

--- a/src/css/styleStudy.scss
+++ b/src/css/styleStudy.scss
@@ -1,4 +1,4 @@
-.upperBox{
+.upperBox {
     margin: 30px;
     display: flex;
     justify-content: space-around;
@@ -15,7 +15,7 @@
         background: green;
     }
 }
-.underBox{
+.underBox {
     margin: 30px;
     display: flex;
     justify-content: space-around;

--- a/src/css/styleStudy.scss
+++ b/src/css/styleStudy.scss
@@ -7,11 +7,11 @@
         background: red;
     }
     .blueBox {
-        padding:  30px;
+        padding: 30px;
         background: blue;
     }
     .greenBox {
-        padding:  30px;
+        padding: 30px;
         background: green;
     }
 }
@@ -20,11 +20,11 @@
     display: flex;
     justify-content: space-around;
     .pinkBox {
-        padding:  30px;
+        padding: 30px;
         background: pink;
     }
     .violetBox {
-        padding:  30px; 
+        padding: 30px; 
         background: violet;
     }
 }

--- a/src/css/styleStudy.scss
+++ b/src/css/styleStudy.scss
@@ -1,0 +1,30 @@
+.boxs1{
+    padding-top: 40px;
+    display: flex;
+    justify-content: space-around;
+    .bc1 {
+         padding: 30px 30px 30px 30px;
+        background   : red;
+    }
+    .bc2 {
+         padding:  30px 30px 30px 30px;
+        background   : blue;
+    }
+    .bc3 {
+         padding:  30px 30px 30px 30px;
+        background   : green;
+    }
+}
+.boxs2{
+    padding-top: 40px ;
+    display: flex;
+    justify-content: space-around;
+    .bc4 {
+         padding:  30px 30px 30px 30px;
+        background   : #ff7f7f;
+    }
+    .bc5 {
+         padding:  30px 30px 30px 30px; 
+        background   : #ff66ff;
+    }
+}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9,6 +9,7 @@ import 'framework7/css/bundle';
 import '../css/icons.css';
 import '../css/app.scss';
 import '../css/study.scss';
+import '../css/styleStudy.scss';
 // Import Cordova APIs
 import cordovaApp from './cordova-app.js';
 

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -3,6 +3,7 @@ import HomePage from '../pages/home.f7';
 import AboutPage from '../pages/about.f7';
 import FormPage from '../pages/form.f7';
 import StudyPage from '../pages/study.f7';
+import StyleStudyPage from '../pages/styleStudy.f7';
 
 import DynamicRoutePage from '../pages/dynamic-route.f7';
 import RequestAndLoad from '../pages/request-and-load.f7';
@@ -24,6 +25,10 @@ var routes = [
   {
     path: '/study/',
     component: StudyPage,
+  },
+  {
+    path: '/styleStudy/',
+    component: StyleStudyPage,
   },
   {
     path: '/dynamic-route/blog/:blogId/post/:postId/',

--- a/src/pages/home.f7
+++ b/src/pages/home.f7
@@ -56,7 +56,6 @@
               </div>
             </a>
           </li>
-
           <li>
             <a href="/study/" class="item-content item-link">
               <div class="item-inner">
@@ -84,7 +83,6 @@
           </div>
         </div>
       </div>
-
       <div class="block-title">Panels</div>
       <div class="block block-strong">
         <div class="row">

--- a/src/pages/home.f7
+++ b/src/pages/home.f7
@@ -64,10 +64,15 @@
               </div>
             </a>
           </li>
-
+          <li>
+            <a href="/styleStudy/" class="item-content item-link">
+              <div class="item-inner">
+                <div class="item-title">StyleStudy</div>
+              </div>
+            </a>
+          </li>
         </ul>
       </div>
-
       <div class="block-title">Modals</div>
       <div class="block block-strong">
         <div class="row">

--- a/src/pages/styleStudy.f7
+++ b/src/pages/styleStudy.f7
@@ -1,0 +1,38 @@
+<template>
+  <div class="page" data-name="study">
+    <div class="navbar">
+      <div class="navbar-bg"></div>
+      <div class="navbar-inner sliding">
+        <div class="left">
+          <a href="#" class="link back">
+            戻る
+          </a>
+        </div>
+        <div class="title">JS学習用ページ</div>
+        <div class="right">
+          <a href="#" class="panel-open" data-panel="right">
+            遷移
+          </a>
+        </div>
+      </div>
+    </div>
+    <div class="page-content">
+      <div class="boxs1">
+        <div class="bc1"></div>
+        <div class="bc2"></div>
+        <div class="bc3"></div>
+      </div>
+      <div class="boxs2">
+        <div class="bc4"></div>
+        <div class="bc5"></div>
+      </div>    
+    </div>
+  </div>
+</template>
+<script>
+export default () => {
+
+return $render;
+}
+</script>
+

--- a/src/pages/styleStudy.f7
+++ b/src/pages/styleStudy.f7
@@ -18,21 +18,14 @@
     </div>
     <div class="page-content">
       <div class="boxs1">
-        <div class="bc1"></div>
-        <div class="bc2"></div>
-        <div class="bc3"></div>
+        <div class="redBox"></div>
+        <div class="blueBox"></div>
+        <div class="greenBox"></div>
       </div>
       <div class="boxs2">
-        <div class="bc4"></div>
-        <div class="bc5"></div>
+        <div class="pinkBox"></div>
+        <div class="violetBox"></div>
       </div>    
     </div>
   </div>
 </template>
-<script>
-export default () => {
-
-return $render;
-}
-</script>
-

--- a/src/pages/styleStudy.f7
+++ b/src/pages/styleStudy.f7
@@ -17,12 +17,12 @@
       </div>
     </div>
     <div class="page-content">
-      <div class="boxs1">
+      <div class="upperBox">
         <div class="redBox"></div>
         <div class="blueBox"></div>
         <div class="greenBox"></div>
       </div>
-      <div class="boxs2">
+      <div class="underBox">
         <div class="pinkBox"></div>
         <div class="violetBox"></div>
       </div>    


### PR DESCRIPTION
# styleStudyページの作成
styleStudyページを新規作成しました。

## 変更点
- src/app.f7
  - styleStudyページへ遷移するパネルのボタンを追加

- src/css/styleStudy.scss
  - styleStudyページのcssを追加

-  src/js/app.js
  - src/css/styleStudy.scssのルーティングを追加

- src/js/routes.js
  - styleStudyページのルーティングを追加

- src/pages/home.f7
  - ho-\meページにstyleStudyページへ遷移するリンクを追加

- src/pages/styleStudy.f7
  - 他ページへ遷移するパネルを追加
  - homeへ戻るリンクを追加
  - ５つの要素を追加

## その他

### 参考資料
- 以下のサイトを参考して実装致しました。
  - [できるネット](https://dekiru.net/article/13241/)
  - [HTMLクイックリファレンス](http://www.htmq.com/style/padding.shtml)

### セルフチェック項目
- [x] `console`にエラーがないことを確認しました。
- [x] ローカルが起動することを確認しました。
- [x] 命名規則は統一して実装しています。
- [x] 複雑な処理にはコメントを残しました。
- [x] RVに必要な情報はPRに全て記載致しました。
- [x] マージ先マージ元のブランチが正しいことを確認致しました。