### PR TITLE
styleStudyページの追加実装

### DIFF
--- a/src/css/styleStudy.scss
+++ b/src/css/styleStudy.scss
@@ -28,3 +28,30 @@
         background: violet;
     }
 }
+.overBox {
+    margin: 30px;
+    .largeBox {
+        position: absolute;
+        padding: 60px;
+        top: 50%;
+        left: 50%;
+        background: red;
+        transform: translate(-50%, -50%);
+    }
+    .mediumBox {
+        position: absolute;
+        padding: 40px;
+        top: 50%;
+        left: 50%;
+        background: magenta;
+        transform: translate(-50%, -50%);
+    }
+    .smallBox {
+        position: absolute;
+        padding: 20px;
+        top: 50%;
+        left: 50%;
+        background: yellow;
+        transform: translate(-50%, -50%);
+    }
+}

--- a/src/css/styleStudy.scss
+++ b/src/css/styleStudy.scss
@@ -29,29 +29,27 @@
     }
 }
 .overBox {
-    margin: 30px;
+    display: flex;
+    justify-content: center;
     .largeBox {
-        position: absolute;
         padding: 60px;
-        top: 50%;
-        left: 50%;
         background: red;
-        transform: translate(-50%, -50%);
-    }
-    .mediumBox {
-        position: absolute;
-        padding: 40px;
-        top: 50%;
-        left: 50%;
-        background: magenta;
-        transform: translate(-50%, -50%);
-    }
-    .smallBox {
-        position: absolute;
-        padding: 20px;
-        top: 50%;
-        left: 50%;
-        background: yellow;
-        transform: translate(-50%, -50%);
+        position: relative;
+        .mediumBox {
+            padding: 40px;
+            background: magenta;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%,-50%);
+        }
+        .smallBox {
+            padding: 20px;
+            background: yellow;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%,-50%);
+        }
     }
 }

--- a/src/pages/styleStudy.f7
+++ b/src/pages/styleStudy.f7
@@ -26,6 +26,11 @@
         <div class="pinkBox"></div>
         <div class="violetBox"></div>
       </div>    
+      <div class="overBox">
+        <div class="largeBox"></div>
+        <div class="mediumBox"></div>
+        <div class="smallBox"></div>
+      </div>
     </div>
   </div>
 </template>

--- a/src/pages/styleStudy.f7
+++ b/src/pages/styleStudy.f7
@@ -27,9 +27,10 @@
         <div class="violetBox"></div>
       </div>    
       <div class="overBox">
-        <div class="largeBox"></div>
-        <div class="mediumBox"></div>
-        <div class="smallBox"></div>
+        <span class="largeBox">
+          <span class="mediumBox"></span>
+          <span class="smallBox"></span>
+        </span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# styleStudyページの追加実装
styleStudyページに新しくボックスを追加しました。

## 変更点
- src/css/styleStudy.scss 
  - 新しく3つの要素を追加しました。

- src/pages/styleStudy.f7
  - 追加した3つの要素を重ねるスタイルを追加
  - 色、サイズなどのスタイルを調整

## その他
### 参照
- [styleStudyページの追加実装](https://github.com/la-learn-terasaki/JavaScript-Enshu/pull/19#top)
### 参考資料
- 以下のサイトを参考して実装致しました。
  - [【CSS/html】divなどの要素を重ねる方法3選](https://csshtml.work/div-on-div/)
  - [【CSS】transformで思い通りのアニメーションを再現](https://web-camp.io/magazine/archives/87247)

### セルフチェック項目
- [x] `console`にエラーがないことを確認しました。
- [x] ローカルが起動することを確認しました。
- [x] 命名規則は統一して実装しています。
- [x] 複雑な処理にはコメントを残しました。
- [x] RVに必要な情報はPRに全て記載致しました。
- [x] マージ先マージ元のブランチが正しいことを確認致しました。